### PR TITLE
Enhance composer and CI settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: php
 
 php:
+  - 7.1
   - 7.2
+  - 7.3
 
 before_script:
   - composer self-update
@@ -14,8 +16,6 @@ after_success:
   - bash <(curl -s https://codecov.io/bash)
 
 matrix:
-  allow_failures:
-    - php: 7.2
   fast_finish: true
 
 notifications:

--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,11 @@
         }
     },
     "require": {
-        "php": ">=7.1",
-        "phpunit/phpunit": "^8.3"
+        "php": ">=7.1"
     },
-    "minimum-stability": "dev"
+    "require-dev": {
+        "phpunit/phpunit": "^7.0"
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }


### PR DESCRIPTION
# Changed log
- Add `php-7.1` and `php-7.3` tests during Travis CI build because the `php-7.1+` version requirements on `composer.json`.
- This package requires `php-7.1` version at least and the `PHPUnit` should be `7.0` at least.
The `PHPUnit 8` version should require `php-7.2` version at least.
-  The package requires `"prefer-stable": true` because `"minimum-stability": "dev",` defined on `composer.json`.

The package will be installed as dependency of stable version when other packages install this.